### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/gangsd92/e3cc0e68-ce18-465d-8e87-024b35f69724/908bd684-ddf0-496d-a1e2-168285ab5046/_apis/work/boardbadge/76fcb101-bbc7-403c-ab48-06b87a9496bd)](https://dev.azure.com/gangsd92/e3cc0e68-ce18-465d-8e87-024b35f69724/_boards/board/t/908bd684-ddf0-496d-a1e2-168285ab5046/Microsoft.RequirementCategory)
 # GShub
 Code


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/gangsd92/e3cc0e68-ce18-465d-8e87-024b35f69724/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.